### PR TITLE
Add required File.Read.All permission note

### DIFF
--- a/api-reference/v1.0/api/drive_sharedwithme.md
+++ b/api-reference/v1.0/api/drive_sharedwithme.md
@@ -69,7 +69,7 @@ Content-Type: application/json
 
 ## Remarks
 
-DriveItems returned from the **sharedWithMe** action will always include the [**remoteItem**](../resources/remoteitem.md) facet which indicates they are items from a different drive. 
+DriveItems returned from the **sharedWithMe** action will always include the [**remoteItem**](../resources/remoteitem.md) facet which indicates they are items from a different drive. The **File.Read.All** permission is required, otherwise **parentReference** is not present on the **remoteItem**.
 To access the shared DriveItem resource, you will need to make a request using the information provided in **remoteItem** in the following format:
 
 <!-- {"blockType": "ignored"} -->


### PR DESCRIPTION
If only the **Files.ReadWrite** permission is requested, the **parentReference** is not returned for *remoteItem*, one also needs the **Files.Read.All** permission.